### PR TITLE
removed faulty test

### DIFF
--- a/Test/src/Client.Test.cs
+++ b/Test/src/Client.Test.cs
@@ -111,20 +111,6 @@ namespace NWN.MasterList.Test
         }
 
         [Fact]
-        public async void TestGetTotalPlayerCount()
-        {
-            var testB = 0;
-            var testA = (await new MasterList.Client().GetServers()).GetTotalPlayerCount();
-
-            foreach (var item in await new MasterList.Client().GetServers())
-            {
-                testB += item.CurrentPlayers;
-            }
-
-            Assert.Equal(testA, testB);
-        }
-
-        [Fact]
         public async void TestGetAllElC()
         {
             var collection = (await new MasterList.Client().GetServers()).GetAllFirstSeen();


### PR DESCRIPTION
This was originally removed because it would fail. It would fail due to the logic of the test.